### PR TITLE
Gradle fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,7 @@ env: #Environment variables that can later be referenced using ${{ env.MINECRAFT
   JAVA_VERSION: 17
   JAVA_LTS: 21
   VERSION: 0.1.0
-  RELEASE_NAME: SmackUtil-1.20.4-0.0.14
-  TAG: V0.1.0
+  TAG: V0.1.1
 
 jobs:
   build:
@@ -110,6 +109,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           automatic_release_tag: "latest"
+          title: ${{ env.TAG }}
           files: |
             fabric/build/libs/*.jar
             forge/build/libs/*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ eclipse
 run
 runClient
 runServer
+runData
 runs

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ build
 # other
 eclipse
 run
+runClient
+runServer
 runs

--- a/common/src/main/java/net/smackplays/smacksutil/platform/Services.java
+++ b/common/src/main/java/net/smackplays/smacksutil/platform/Services.java
@@ -5,25 +5,15 @@ import net.smackplays.smacksutil.platform.services.*;
 
 import java.util.ServiceLoader;
 
-// Service loaders are a built-in Java feature that allow us to locate implementations of an interface that vary from one
-// environment to another. In the context of MultiLoader we use this feature to access a mock API in the common code that
-// is swapped out for the platform specific implementation at runtime.
 public class Services {
 
-    // In this example we provide a platform helper which provides information about what platform the mod is running on.
-    // For example this can be used to check if the code is running on Forge vs Fabric, or to ask the modloader if another
-    // mod is loaded.
     public static final IPlatformHelper PLATFORM = load(IPlatformHelper.class);
     public static final IModConfig CONFIG = load_1(IModConfig.class);
     public static final IVeinMiner VEIN_MINER = load(IVeinMiner.class);
-    public static final IKeyHandler KEY_HANDLER = load(IKeyHandler.class);
+    public static final IKeyHandler KEY_HANDLER = load_1(IKeyHandler.class);
     public static final IClientPacketSender C2S_PACKET_SENDER = load_1(IClientPacketSender.class);
     public static final IServerPacketSender S2C_PACKET_SENDER = load(IServerPacketSender.class);
 
-    // This code is used to load a service for the current environment. Your implementation of the service must be defined
-    // manually by including a text file in META-INF/services named with the fully qualified class name of the service.
-    // Inside the file you should write the fully qualified class name of the implementation to load for the platform. For
-    // example our file on Forge points to ForgePlatformHelper while Fabric points to FabricPlatformHelper.
     public static <T> T load(Class<T> clazz) {
 
         final T loadedService = ServiceLoader.load(clazz)

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -54,13 +54,13 @@ loom {
             client()
             setConfigName("Fabric Client")
             ideConfigGenerated(true)
-            runDir("run")
+            runDir("runClient")
         }
         server {
             server()
             setConfigName("Fabric Server")
             ideConfigGenerated(true)
-            runDir("run")
+            runDir("runServer")
         }
     }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -72,7 +72,7 @@ minecraft {
 
     runs {
         client {
-            workingDirectory project.file('run')
+            workingDirectory project.file('runClient')
             ideaModule "${rootProject.name}.${project.name}.main"
             args '--mod', mod_id, 'smacksutil'
             taskName 'Client'
@@ -87,7 +87,7 @@ minecraft {
         }
 
         server {
-            workingDirectory project.file('run')
+            workingDirectory project.file('runServer')
             ideaModule "${rootProject.name}.${project.name}.main"
             taskName 'Server'
             property 'mixin.env.remapRefMap', 'true'
@@ -101,7 +101,7 @@ minecraft {
         }
 
         data {
-            workingDirectory project.file('run')
+            workingDirectory project.file('runData')
             ideaModule "${rootProject.name}.${project.name}.main"
             args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
             taskName 'Data'


### PR DESCRIPTION
Split run directory in runClient and runServer for forge and fabric. This avoids client and server accessing the same files when run together.